### PR TITLE
support gapFiller (gap-filler) option in remark-cq

### DIFF
--- a/packages/remark-cq/index.js
+++ b/packages/remark-cq/index.js
@@ -154,6 +154,10 @@ function codeImportBlock(eat, value, silent) {
   if (__lastBlockAttributes["lang"]) {
     cqOpts.language = dequote(__lastBlockAttributes["lang"]);
   }
+  if (__lastBlockAttributes["gap-filler"]) {
+    cqOpts.gapFiller =
+      "\n " + dequote(__lastBlockAttributes["gap-filler"]) + "\n";
+  }
 
   let newNode = {
     type: "cq",
@@ -445,6 +449,9 @@ async function visitCq(ast, vFile, options) {
         let cqOpts = { ...node.options };
         if (!cqOpts.engine) {
           cqOpts.engine = engine;
+        }
+        if (!cqOpts.gapFiller) {
+          cqOpts.gapFiller = "\n  // ...\n";
         }
         debug(`${actualFilename} ` + JSON.stringify(cqOpts, null, 2));
 


### PR DESCRIPTION
If you want to set gap filler, add `gap-filler` option to config like so:

```
{lang=tsx,engine=treesitter,gap-filler="// prev code here...",line-numbers=off,crop-query=(23-24,42)}
<<[](./AppStateContext.tsx)
```

By default `gap-filler` is set to `// ...`